### PR TITLE
docs: Add guide for Gemini Code Assist

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@
 - [Google AI Studio Guide](./guides/ai-studio.md) - A guide to getting started with Google AI Studio.
 - [Gemini Learning Tools Guide](./guides/learning-tools.md) - Learn how to use Gemini's new learning tools to study more effectively.
 - [Jules: Your AI Coding Partner](./guides/jules.md) - A guide to working with Jules, your AI coding partner.
+- [Gemini Code Review Guide](./guides/gemini-code-review.md) - A guide to using Gemini Code Assist for code reviews in GitHub.
 
 ---
 

--- a/guides/gemini-code-review.md
+++ b/guides/gemini-code-review.md
@@ -1,0 +1,41 @@
+# Gemini Code Review Guide
+
+This guide explains how to use Gemini Code Assist to review your code in GitHub.
+
+Gemini Code Assist is a powerful tool that can help you improve the quality of your code by providing automatic code reviews on your pull requests. It is a GitHub App that you need to install and configure in your repository.
+
+## How it Works
+
+Gemini Code Assist uses a Gemini-powered agent to:
+
+*   Automatically summarize pull requests.
+*   Provide in-depth code reviews.
+*   Answer your questions about the pull request.
+
+## Installation
+
+To install Gemini Code Assist, you need to:
+
+1.  Go to the [Gemini Code Assist for GitHub app page](https://github.com/apps/gemini-code-assist).
+2.  Click "Install" and select the organization and repositories where you want to use it.
+3.  Follow the on-screen instructions to complete the setup.
+
+## Usage
+
+Once installed, Gemini Code Assist will automatically review new pull requests. It will add a comment to the pull request with its feedback.
+
+You can also manually invoke Gemini Code Assist by adding comments to the pull request with the following commands:
+
+*   `/gemini summary`: Posts a summary of the changes in the pull request.
+*   `/gemini review`: Posts a code review of the changes in the pull request.
+*   `/gemini help`: Shows an overview of the available commands.
+
+## Customization
+
+You can customize the behavior of Gemini Code Assist by creating a `.github/gemini.yml` file in your repository. This file allows you to:
+
+*   Define a custom style guide.
+*   Configure the severity of the issues that Gemini reports.
+*   And much more.
+
+For more detailed information, please refer to the [official documentation](https://developers.google.com/gemini-code-assist/docs/review-github-code).


### PR DESCRIPTION
This commit adds a new guide that explains how to install and use the Gemini Code Assist for GitHub. This is a GitHub App that provides automatic code reviews on pull requests.

The main `README.md` has been updated to include a link to this new guide.